### PR TITLE
rbd: support for single-major device number allocation scheme

### DIFF
--- a/Documentation/ABI/testing/sysfs-bus-rbd
+++ b/Documentation/ABI/testing/sysfs-bus-rbd
@@ -18,6 +18,28 @@ Removal of a device:
 
   $ echo <dev-id> > /sys/bus/rbd/remove
 
+What:		/sys/bus/rbd/add_single_major
+Date:		December 2013
+KernelVersion:	3.14
+Contact:	Sage Weil <sage@inktank.com>
+Description:	Available only if rbd module is inserted with single_major
+		parameter set to true.
+		Usage is the same as for /sys/bus/rbd/add.  If present,
+		should be used instead of the latter: any attempts to use
+		/sys/bus/rbd/add if /sys/bus/rbd/add_single_major is
+		available will fail for backwards compatibility reasons.
+
+What:		/sys/bus/rbd/remove_single_major
+Date:		December 2013
+KernelVersion:	3.14
+Contact:	Sage Weil <sage@inktank.com>
+Description:	Available only if rbd module is inserted with single_major
+		parameter set to true.
+		Usage is the same as for /sys/bus/rbd/remove.  If present,
+		should be used instead of the latter: any attempts to use
+		/sys/bus/rbd/remove if /sys/bus/rbd/remove_single_major is
+		available will fail for backwards compatibility reasons.
+
 Entries under /sys/bus/rbd/devices/<dev-id>/
 --------------------------------------------
 


### PR DESCRIPTION
This series adds support for single-major device number allocation
scheme, which is needed to break through the limit of ~230 rbd images
mapped at once.  The new limit is 4096 and can be relatively easily
upped in the future by giving users control over the number of minor
numbers to reserve for each mapping.

Fixes: http://tracker.ceph.com/issues/5048

Signed-off-by: Ilya Dryomov ilya.dryomov@inktank.com
Reviewed-by: Alex Elder elder@linaro.org
Reviewed-by: Josh Durgin josh.durgin@inktank.com
