### PR TITLE
kernel rbd:: messenger: fix addr_is_blank() to deal with initial empty address

### DIFF
--- a/net/ceph/messenger.c
+++ b/net/ceph/messenger.c
@@ -1736,7 +1736,7 @@ static bool addr_is_blank(struct sockaddr_storage *ss)
 		     ((struct sockaddr_in6 *)ss)->sin6_addr.s6_addr32[2] == 0 &&
 		     ((struct sockaddr_in6 *)ss)->sin6_addr.s6_addr32[3] == 0;
 	}
-	return false;
+	return true;
 }
 
 static int addr_port(struct sockaddr_storage *ss)


### PR DESCRIPTION
When addr is first initialized or it is really empty, it does not mean ip = 0.0.0.0, but also ss_family may be not defined. It is neither ipv4 nor ipv6. Thus, we may treat those cases correctly and consider it as empty address. So it should return true, not false. The current version kernel rbd will lead to osd printing warnning: "accept peer addr is really 'peer_addr' socket is 'socket_addr ', which is caused by the kernel rbd not learning it address correctly. As addr is initialized as zero memery so that ss_family is neither AF_INET nor AF_INET6, thus it return false to indicate ip is not empty, but it should be empty.