### PR TITLE
libceph: rename mount option osdkeepalive to osdkeepalivetimeout

### DIFF
--- a/net/ceph/ceph_common.c
+++ b/net/ceph/ceph_common.c
@@ -253,7 +253,7 @@ enum {
 
 static match_table_t opt_tokens = {
 	{Opt_osdtimeout, "osdtimeout=%d"},
-	{Opt_osdkeepalivetimeout, "osdkeepalive=%d"},
+	{Opt_osdkeepalivetimeout, "osdkeepalivetimeout=%d"},
 	{Opt_mount_timeout, "mount_timeout=%d"},
 	{Opt_osd_idle_ttl, "osd_idle_ttl=%d"},
 	/* int args above */


### PR DESCRIPTION
This option osdkeepalivetimeout is documented in manpage and officical website, but the valid option name can be used is osdkeepalive. It is better to rename it for matching manpage and user to understand its meaning.

Fixes: #17098 (http://tracker.ceph.com/issues/17098)
Signed-off-by: Zhi Zhang <willzzhang@tencent.com>