### PR TITLE
doc: fix description for rsize and rasize

### DIFF
--- a/Documentation/filesystems/ceph.txt
+++ b/Documentation/filesystems/ceph.txt
@@ -98,6 +98,10 @@ Mount Options
 	size.
 
   rsize=X
+	Specify the maximum read size in bytes.  By default there is no
+	maximum.
+
+  rasize=X
 	Specify the maximum readahead.
 
   mount_timeout=X


### PR DESCRIPTION
looks like a typo happened when documenting the `rsize`/`rasize` option
the comments in `fs/ceph/super.h` document the real meaning:
```
int rsize;            /* max read size */
int rasize;           /* max readahead */
```