### PR TITLE
Failed to write data to rbd device even removed from blacklist

### DIFF
--- a/drivers/block/rbd.c
+++ b/drivers/block/rbd.c
@@ -3471,18 +3471,27 @@ static void rbd_reregister_watch(struct work_struct *work)
 	ret = __rbd_register_watch(rbd_dev);
 	if (ret) {
 		rbd_warn(rbd_dev, "failed to reregister watch: %d", ret);
-		if (ret == -EBLACKLISTED || ret == -ENOENT) {
+		if (ret == -ENOENT) {
 			set_bit(RBD_DEV_FLAG_BLACKLISTED, &rbd_dev->flags);
 			wake_requests(rbd_dev, true);
-		} else {
+		} 
+		else if(ret == -EBLACKLISTED) {
+			set_bit(RBD_DEV_FLAG_BLACKLISTED, &rbd_dev->flags);
+			wake_requests(rbd_dev, true);
 			queue_delayed_work(rbd_dev->task_wq,
 					   &rbd_dev->watch_dwork,
 					   RBD_RETRY_DELAY);
-		}
-		mutex_unlock(&rbd_dev->watch_mutex);
-		return;
+	        }
+	        else {
+			queue_delayed_work(rbd_dev->task_wq,
+					   &rbd_dev->watch_dwork,
+					   RBD_RETRY_DELAY);
+			}
+			mutex_unlock(&rbd_dev->watch_mutex);
+			return;
 	}
-
+	clear_bit(RBD_DEV_FLAG_BLACKLISTED, &rbd_dev->flags)
+    
 	rbd_dev->watch_state = RBD_WATCH_STATE_REGISTERED;
 	rbd_dev->watch_cookie = rbd_dev->watch_handle->linger_id;
 	mutex_unlock(&rbd_dev->watch_mutex);


### PR DESCRIPTION
Map rbd to multiple nodes as the iscsi target and use multipath on iscsi initiator.path_grouping_policy is failover.The iscsi initiator sends data to the target. When the active path of is broken because the Internet problem, the data is switched to the alternate path. However, the original path is added to the blacklist. After the path is restored, the path is removed from the blacklist. , but the rbd device on the path failed to write data.