### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/drivers/usb/serial/digi_acceleport.c
+++ b/drivers/usb/serial/digi_acceleport.c
@@ -1228,8 +1228,27 @@ static int digi_port_init(struct usb_serial_port *port, unsigned port_num)
 
 static int digi_startup(struct usb_serial *serial)
 {
+	struct device *dev = &serial->interface->dev;
 	struct digi_serial *serial_priv;
 	int ret;
+	int i;
+
+	/* check whether the device has the expected number of endpoints */
+	if (serial->num_port_pointers < serial->type->num_ports + 1) {
+		dev_err(dev, "OOB endpoints missing\n");
+		return -ENODEV;
+	}
+
+	for (i = 0; i < serial->type->num_ports + 1 ; i++) {
+		if (!serial->port[i]->read_urb) {
+			dev_err(dev, "bulk-in endpoint missing\n");
+			return -ENODEV;
+		}
+		if (!serial->port[i]->write_urb) {
+			dev_err(dev, "bulk-out endpoint missing\n");
+			return -ENODEV;
+		}
+	}
 
 	serial_priv = kzalloc(sizeof(*serial_priv), GFP_KERNEL);
 	if (!serial_priv)


### PR DESCRIPTION
Hi Development team,

Our tool identified a potential vulnerability in a clone function `digi_startup()` in `drivers/usb/serial/digi_acceleport.c` sourced from [torvalds/linux](https://github.com/torvalds/linux). These issues, originally reported in [CVE-2016-3140](https://nvd.nist.gov/vuln/detail/CVE-2016-3140), were resolved in the repository via this commit https://github.com/torvalds/linux/commit/5a07975ad0a36708c6b0a5b9fea1ff811d0b0c1f.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you for your time and attention!