### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/drivers/net/hamradio/mkiss.c
+++ b/drivers/net/hamradio/mkiss.c
@@ -793,14 +793,14 @@ static void mkiss_close(struct tty_struct *tty)
 	 * on our buffers
 	 */
 	netif_stop_queue(ax->dev);
+	
+	ax->tty = NULL;
 
 	unregister_netdev(ax->dev);
 
 	/* Free all AX25 frame buffers after unreg. */
 	kfree(ax->rbuff);
 	kfree(ax->xbuff);
-
-	ax->tty = NULL;
 
 	free_netdev(ax->dev);
 }


### PR DESCRIPTION
Hi again,

Our tool identified a potential vulnerability in a clone function in `drivers/net/hamradio/mkiss.c` sourced from [torvalds/linux](https://github.com/torvalds/linux). These issues, originally reported in [CVE-2022-1195](https://nvd.nist.gov/vuln/detail/CVE-2022-1195), were resolved in the repository via this commit https://github.com/torvalds/linux/commit/b2f37aead1b82a770c48b5d583f35ec22aabb61e.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you for your time and attention!