### PR TITLE
Fix potential vulnerable cloned function

### DIFF
--- a/drivers/net/wireless/ath/ath9k/wmi.c
+++ b/drivers/net/wireless/ath/ath9k/wmi.c
@@ -353,6 +353,7 @@ int ath9k_wmi_cmd(struct wmi *wmi, enum wmi_cmd_id cmd_id,
 		wmi->last_seq_id = 0;
 		spin_unlock_irqrestore(&wmi->wmi_lock, flags);
 		mutex_unlock(&wmi->op_mutex);
+		kfree_skb(skb);
 		return -ETIMEDOUT;
 	}
 


### PR DESCRIPTION
Hi again,

Our tool identified a potential vulnerability in a clone function in `drivers/net/wireless/ath/ath9k/wmi.c` sourced from [torvalds/linux](https://github.com/torvalds/linux). These issues, originally reported in [CVE-2019-19074](https://nvd.nist.gov/vuln/detail/CVE-2019-19074), were resolved in the repository via this commit https://github.com/torvalds/linux/commit/728c1e2a05e4b5fc52fab3421dce772a806612a2.

This PR applies the corresponding patch to fix the vulnerabilities in this codebase.

Please review at your convenience. Thank you for your time and attention!